### PR TITLE
Wacom Support, absolute x,y pressure; relative scroll; forward/back buttons; platform address width case for event timestamp

### DIFF
--- a/evdev.lisp
+++ b/evdev.lisp
@@ -154,25 +154,47 @@ used outside of this package.")
       (116 . (:name power            :glyph nil))
       (117 . (:name kpequal          :glyph #\=))
       (118 . (:name kpplusminus      :glyph nil))
-      (119 . (:name pause            :glyph nil)))
-  :test #'equal
+      (119 . (:name pause            :glyph nil))
+      (277 . (:name btnforward      :glyph nil))
+      (278 . (:name btnback         :glyph nil)))      
+   :test #'equal
   :documentation "List of key code to key symbol name and printable character.
 Used to decode the code field of the Linux input_event struct defined in
 linux/include/uapi/linux/input.h.")
 
-(define-unsigned unsigned-long-int 8)
+(define-constant +input-abs-codes+
+ '((0 . (:name ABS_X))
+   (1 . (:name ABS_Y))
+   (24 . (:name ABS_PRESSURE))
+   (40 . (:name ABS_MISC)))
+  :test #'equal
+  :documentation "Absolute device values for pointer and tablet hardware."
+)
+
+(define-constant +input-rel-codes+
+ '((8 . (:name REL_WHEEL)))
+  :test #'equal
+  :documentation "Relative motion types."
+)
+
+
+(cond ((equal (machine-type) "X86") 
+       (define-unsigned unsigned-long-int 4))
+      ((equal (machine-type) "X86-64") 
+       (define-unsigned unsigned-long-int 8))
+      (t 4))
 (define-unsigned unsigned-short 2)
 (define-unsigned unsigned-int 4)
 
 (define-binary-class input-event-struct ()
-  ((tv_sec  :binary-type unsigned-long-int)
+  ((tv_sec  :binary-type unsigned-long-int)			     
    (tv_usec :binary-type unsigned-long-int)
    (type    :binary-type unsigned-short)
-   (code    :binary-type unsigned-short)
-   (value   :binary-type unsigned-int))
+   (code    :binary-type unsigned-short) 
+   (value   :binary-type unsigned-int)) 
   (:documentation "This is a verbaticm copy of the input_event struct defined in
 linux/include/uapi/linux/input.h. This is used to read in each event straight
-from raw evdev data."))
+from raw evdev data. Unix time values bit widths differ on 32/64bit systems."))
 
 (defclass input-event (event)
   ((timestamp :initarg :timestamp
@@ -182,11 +204,11 @@ from raw evdev data."))
 (defmethod print-object ((object input-event-struct) stream)
   (print-unreadable-object (object stream :type t)
     (with-slots (tv_sec tv_usec type code value) object
-      (let ((type (cdr (assoc type +input-event-types+))))
+      (let ((typee (cdr (assoc type +input-event-types+))))
         (format stream ":TV_SEC ~a :TV_USEC ~a :TYPE ~a :CODE ~a :VALUE ~a"
                 tv_sec tv_usec type code value)))))
 
-(defmethod print-object ((object input-event) stream)
+(defmethod print-object ((object input-event) stream) 
   (print-unreadable-object (object stream :type t)
     (with-slots (timestamp) object
       (format stream ":TIMESTAMP ~a"
@@ -210,7 +232,7 @@ from raw evdev data."))
           "The character code point for this key. May be NIL."))
   (:documentation "An INPUT-EVENT that contains keyboard-specific state data."))
 
-(defmethod print-object ((object keyboard-event) stream)
+(defmethod print-object ((object keyboard-event) stream)  
   (print-unreadable-object (object stream :type t)
     (with-slots (name glyph state) object
       (format stream ":NAME ~a :GLYPH ~a :STATE ~a" name glyph state))))
@@ -231,6 +253,31 @@ and the next SYNC-EVENT."))
 (defclass misc-event (input-event)
   ()
   (:documentation "Represents a miscellaneous evdev event."))
+
+(defclass absolute-event (input-event)
+  ((value :initarg :value
+	  :type integer)
+   (type  :initarg :type
+	  :type (or :x :y :pressure :misc)))
+  (:documentation "An INPUT-EVENT that contains absolute position data."))
+
+(defmethod print-object ((object absolute-event) stream)
+  (print-unreadable-object (object stream :type t)
+    (with-slots (type value) object
+      (format stream ":TYPE ~a :VALUE ~a" type value))))
+
+(defclass relative-event (input-event)
+  ((value :initarg :value
+	  :type integer)
+   (type  :initarg :type
+	  :type (or :wheel :misc)))
+  (:documentation "An INPUT-EVENT that contains relative motion data."))
+
+(defmethod print-object ((object relative-event) stream)
+  (print-unreadable-object (object stream :type t)
+    (with-slots (type value) object
+      (format stream ":TYPE ~a :VALUE ~a " type value))))
+
 
 (defun read-raw-event (stream)
   "Reads in a single INPUT-EVENT-STRUCT from STREAM."
@@ -263,15 +310,29 @@ and the next SYNC-EVENT."))
                                 :name name
                                 :glyph glyph
                                 :state state)))
+	      ((eq event-type :ev-abs)
+	       (let* ((abs-code (rest (assoc code +input-abs-codes+)))
+                      (type (getf abs-code :type)))
+                 (make-instance 'absolute-event
+                                :timestamp timestamp
+                                :type abs-code
+				:value value)))
               ((eq event-type :ev-msc)
                (make-instance 'misc-event
-                              :timestamp timestamp))
+                              :timestamp nil))
+	      ((eq event-type :ev-rel)
+	       (let* ((abs-code (rest (assoc code +input-rel-codes+)))
+                      (type (getf abs-code :type)))
+                 (make-instance 'relative-event
+                                :timestamp timestamp
+                                :type abs-code
+				:value value)))
               ((eq event-type :ev-syn)
                (let ((syn-code (rest (assoc code +input-syn-codes+))))
                  (make-instance 'sync-event
                                 :timestamp timestamp
-                                :dropped-events (eq syn-code :syn-dropped))))
-              (t (warn "Unknown evdev event type ~S" event-type) nil))))))
+                                :dropped-events (eq syn-code :syn-dropped))))	      
+	       (t (warn "Unknown evdev event type ~S" event-type) nil))))))
 
 (defmacro with-evdev-device ((event-var device-path)
                              &body body)

--- a/evdev.lisp
+++ b/evdev.lisp
@@ -204,7 +204,7 @@ from raw evdev data. Unix time values bit widths differ on 32/64bit systems."))
 (defmethod print-object ((object input-event-struct) stream)
   (print-unreadable-object (object stream :type t)
     (with-slots (tv_sec tv_usec type code value) object
-      (let ((typee (cdr (assoc type +input-event-types+))))
+      (let ((type (cdr (assoc type +input-event-types+))))
         (format stream ":TV_SEC ~a :TV_USEC ~a :TYPE ~a :CODE ~a :VALUE ~a"
                 tv_sec tv_usec type code value)))))
 
@@ -232,7 +232,7 @@ from raw evdev data. Unix time values bit widths differ on 32/64bit systems."))
           "The character code point for this key. May be NIL."))
   (:documentation "An INPUT-EVENT that contains keyboard-specific state data."))
 
-(defmethod print-object ((object keyboard-event) stream)  
+(defmethod print-object ((object keyboard-event) stream)
   (print-unreadable-object (object stream :type t)
     (with-slots (name glyph state) object
       (format stream ":NAME ~a :GLYPH ~a :STATE ~a" name glyph state))))
@@ -319,7 +319,7 @@ and the next SYNC-EVENT."))
 				:value value)))
               ((eq event-type :ev-msc)
                (make-instance 'misc-event
-                              :timestamp nil))
+                              :timestamp timestamp))
 	      ((eq event-type :ev-rel)
 	       (let* ((abs-code (rest (assoc code +input-rel-codes+)))
                       (type (getf abs-code :type)))
@@ -331,8 +331,8 @@ and the next SYNC-EVENT."))
                (let ((syn-code (rest (assoc code +input-syn-codes+))))
                  (make-instance 'sync-event
                                 :timestamp timestamp
-                                :dropped-events (eq syn-code :syn-dropped))))	      
-	       (t (warn "Unknown evdev event type ~S" event-type) nil))))))
+                                :dropped-events (eq syn-code :syn-dropped))))
+	      (t (warn "Unknown evdev event type ~S" event-type) nil))))))
 
 (defmacro with-evdev-device ((event-var device-path)
                              &body body)

--- a/evdev.lisp
+++ b/evdev.lisp
@@ -194,7 +194,8 @@ linux/include/uapi/linux/input.h.")
    (value   :binary-type unsigned-int)) 
   (:documentation "This is a verbaticm copy of the input_event struct defined in
 linux/include/uapi/linux/input.h. This is used to read in each event straight
-from raw evdev data. Unix time values bit widths differ on 32/64bit systems."))
+from raw evdev data. Unix time values bit widths differ on 32/64bit systems and
+based on the return value of (machine-type) in SBCL."))
 
 (defclass input-event (event)
   ((timestamp :initarg :timestamp


### PR DESCRIPTION
Wacom Support, absolute x,y pressure; relative scroll; forward/back buttons; platform address width case for event timestamp

library will not work on 32 bit systems without unsigned-long-integer case fix included in this commit

tested on Wacom CTE-440 and Lenovo Black Silk keyboard