### PR TITLE
Broader handling of architectures; WITH-EVENT-DEVICES macro

### DIFF
--- a/cl-evdev.asd
+++ b/cl-evdev.asd
@@ -8,6 +8,7 @@
     :depends-on (#:binary-types
                  #:alexandria
                  #:local-time
+		 #:trivial-features
                  #:cl-event-handler)
     :components ((:file "package")
                  (:file "evdev")))

--- a/evdev.lisp
+++ b/evdev.lisp
@@ -175,11 +175,8 @@ linux/include/uapi/linux/input.h.")
   :test #'equal
   :documentation "Relative motion types.")
 
-(cond ((member (machine-type) '("X86" "armv7l") :test #'equal)
-       (define-unsigned unsigned-long-int 4))
-      ((member (machine-type) '("X86-64" "x86_64") :test #'equal)
-       (define-unsigned unsigned-long-int 8))
-      (t 4))
+#+32-bit(define-unsigned unsigned-long-int 4)
+#+64-bit(define-unsigned unsigned-long-int 8)
 
 (define-unsigned unsigned-short 2)
 (define-unsigned unsigned-int 4)

--- a/evdev.lisp
+++ b/evdev.lisp
@@ -175,10 +175,12 @@ linux/include/uapi/linux/input.h.")
   :test #'equal
   :documentation "Relative motion types.")
 
+(cond ((member (machine-type) '("X86" "armv7l") :test #'equal)
        (define-unsigned unsigned-long-int 4))
-      ((equal (machine-type) "X86-64")
+      ((member (machine-type) '("X86-64" "x86_64") :test #'equal)
        (define-unsigned unsigned-long-int 8))
       (t 4))
+
 (define-unsigned unsigned-short 2)
 (define-unsigned unsigned-int 4)
 

--- a/evdev.lisp
+++ b/evdev.lisp
@@ -168,17 +168,13 @@ linux/include/uapi/linux/input.h.")
    (24 . (:name ABS_PRESSURE))
    (40 . (:name ABS_MISC)))
   :test #'equal
-  :documentation "Absolute device values for pointer and tablet hardware."
-)
+  :documentation "Absolute device values for pointer and tablet hardware.")
 
 (define-constant +input-rel-codes+
  '((8 . (:name REL_WHEEL)))
   :test #'equal
-  :documentation "Relative motion types."
-)
+  :documentation "Relative motion types.")
 
-
-(cond ((equal (machine-type) "X86")
        (define-unsigned unsigned-long-int 4))
       ((equal (machine-type) "X86-64")
        (define-unsigned unsigned-long-int 8))

--- a/evdev.lisp
+++ b/evdev.lisp
@@ -223,12 +223,10 @@ based on the return value of (machine-type) in SBCL."))
 :REPEAT.")
    (name :initarg :name
          :accessor :name
-         :type symbol
          :documentation
          "The human-readable name for the key. Every key event has one.")
    (glyph :initarg :glyph
           :accessor :glyph
-          :type symbol
           :documentation
           "The character code point for this key. May be NIL."))
   (:documentation "An INPUT-EVENT that contains keyboard-specific state data."))

--- a/package.lisp
+++ b/package.lisp
@@ -4,6 +4,7 @@
   (:use #:cl #:binary-types #:alexandria #:local-time #:cl-event-handler)
   (:documentation "Linux keyboard event input driver.")
   (:export #:with-evdev-device
+	   #:with-evdev-devices
 
            #:input-event
            #:keyboard-event


### PR DESCRIPTION
Please consider the following changes:

* Add trivial-features dependency to determine the word size across architectures/compilers
* WITH-EVDEV-DEVICES allowing handling of several input event devices as the same blocking operation